### PR TITLE
Fix drone array declaration order

### DIFF
--- a/uzay/script.js
+++ b/uzay/script.js
@@ -83,6 +83,7 @@
   }
 
   // Guardian drones patrol selected planets
+  const drones = [];
   for (let i = 1; i < planets.length; i += 3) {
     if (planets[i]) drones.push(createDrone(i));
   }
@@ -118,7 +119,6 @@
     r: 12,
   };
 
-  const drones = [];
   const enemyShots = [];
   const trailPoints = [];
   let trailTimer = 0;


### PR DESCRIPTION
## Summary
- move the drones array declaration above the guardian drone patrol loop so it is defined before use
- remove the redundant later declaration to avoid duplicate definitions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cdd6c10bec8321b0887b546b0ff612